### PR TITLE
fix: Ko-fi funding format

### DIFF
--- a/.GitHub/FUNDING.YML
+++ b/.GitHub/FUNDING.YML
@@ -1,1 +1,1 @@
-Kofi:garnetlabs
+ko_fi: garnetlabs


### PR DESCRIPTION
Fixes the broken Sponsor link on GitHub

https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository